### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,4 @@ setup(name='PyFingerprint',
           "gensim",
           "scikit-learn",
           "tqdm",
-          "rdkit-pypi"])
+          "rdkit"])


### PR DESCRIPTION
RDKit is now available from `rdkit` instead of `rdkit-pypi`
https://pypi.org/project/rdkit-pypi/.