### PR TITLE
Fix rdkit morgan fingerprint radius

### DIFF
--- a/PyFingerprint/fingerprint.py
+++ b/PyFingerprint/fingerprint.py
@@ -73,7 +73,7 @@ def get_fingerprint(smi: str, fp_type: str, nbit=None, depth=None):
         for i, k in enumerate(bits):
             fp[k] = 1
     elif fp_type in rdktypes:
-        fp = list(rdk_fingerprint(smi, fp_type, size=nbit))
+        fp = list(rdk_fingerprint(smi, fp_type, size=nbit, depth=depth))
 
     elif fp_type in babeltypes:
         fp = ob_fingerprint(smi, fp_type)


### PR DESCRIPTION
After checking some calculations, I noticed that generating ECFP4 and ECFP6 fingerprints gave the same results.
I quickly checked the code, and the depth parameter wasn't being updated properly, meaning it always fell back to a depth of 3.
With this fix, setting the depth to 2 should correctly generate the corresponding ECFP4 fingerprint.